### PR TITLE
Fix dependency conflict with python version, s/3.6.7/3.6/

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ conda env create -f environment.yml
 conda activate robotics-class
 ```
 
-Although you don't technically _have to_ use Anaconda and Python 3.6.7, this is how we will be grading it, and if it doesn't work on our grading computer, we won't try too hard to make it work.
+Although you don't technically _have to_ use Anaconda and Python 3.6, this is how we will be grading it, and if it doesn't work on our grading computer, we won't try too hard to make it work.
 You should not still be using Python 2 (it's no longer supported, after all) and we have no intention of running your code in a Python 2 environment. However, _if_ you are still using Python 2.7, you can install Anaconda without messing up your current Python installation. Anaconda also makes sure that the installed libraries don't affect other projects on the same machine. There are other tools to do this as well (ask the TAs if you really want to get into it about Python tooling).
 
 Before starting each homework, you will first need to update the repository to get the new files.

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - python=3.6.7 
+  - python=3.6
   - scikit-image=0.17.2
   - scipy=1.5.3
   - tqdm


### PR DESCRIPTION
This PR changes the conda environment to pin to the minor version not the patch version of 3.6.

## Background
As described in the README, I cloned the repo and attempted to build the conda environment:

```
git clone https://github.com/fishbotics/uw-robotics-571-sp21.git
cd uw-robotics-571-sp21
conda deactivate
conda env create -f environment.yml
```

But I get a slew of dependency conflicts which do not allow creating the env:

https://gist.github.com/keyan/c366cd3db28c6be188c59c53e5cf3aa4

Either of these approaches worked to resolved this:
1. Reverting the last commit on the repo, https://github.com/fishbotics/uw-robotics-571-sp21/commit/cda2811f37570b3fe98ded821aa11c51cabec062
2. (This PR) changing the pinned Python version to the minor version