### PR TITLE
parameterize tests

### DIFF
--- a/tests/hw1_tests/test_activation_gradient.py
+++ b/tests/hw1_tests/test_activation_gradient.py
@@ -1,10 +1,12 @@
+import pytest
 import numpy as np
 
 from nn.layers import ReLULayer
 from tests import utils
 
-
-def _test_backward_approx(layer, data_shape):
+@pytest.mark.parametrize("data_shape", [(10, 20, 30)])
+@pytest.mark.parametrize("layer", [ReLULayer()])
+def test_backward_approx(layer, data_shape):
     h = 1e-4
     data = np.random.random(data_shape) * 10 - 5
     data[np.abs(data) < h] = 1
@@ -17,12 +19,3 @@ def _test_backward_approx(layer, data_shape):
     output_gradient = layer.backward(previous_partial_gradient)
 
     utils.assert_close((output1 - output2) / (2 * h), output_gradient)
-
-
-def test_layers():
-    layers = [
-        (ReLULayer(), (10, 20, 30)),
-    ]
-
-    for layer, data_shape in layers:
-        _test_backward_approx(layer, data_shape)

--- a/tests/hw1_tests/test_linear_layer.py
+++ b/tests/hw1_tests/test_linear_layer.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 import torch
 from torch import nn
@@ -8,7 +10,11 @@ from tests import utils
 TOLERANCE = 1e-4
 
 
-def _test_linear_forward(input_shape, out_channels):
+@pytest.mark.parametrize("batch_size", list(range(1, 4)))
+@pytest.mark.parametrize("input_channels", list(range(1, 5)))
+@pytest.mark.parametrize("out_channels", list(range(1, 5)))
+def test_linear_forward(batch_size, input_channels, out_channels):
+    input_shape = (batch_size, input_channels)
     in_channels = input_shape[1]
     input = np.random.random(input_shape).astype(np.float32) * 20
     original_input = input.copy()
@@ -27,15 +33,11 @@ def _test_linear_forward(input_shape, out_channels):
     utils.assert_close(output, torch_out, atol=TOLERANCE)
 
 
-def test_linear_forward():
-    for batch_size in range(1, 4):
-        for input_channels in range(1, 5):
-            for output_channels in range(1, 5):
-                input_shape = (batch_size, input_channels)
-                _test_linear_forward(input_shape, output_channels)
-
-
-def _test_linear_backward(input_shape, out_channels):
+@pytest.mark.parametrize("batch_size", list(range(1, 4)))
+@pytest.mark.parametrize("input_channels", list(range(1, 5)))
+@pytest.mark.parametrize("out_channels", list(range(1, 5)))
+def test_linear_backward(batch_size, input_channels, out_channels):
+    input_shape = (batch_size, input_channels)
     in_channels = input_shape[1]
     input = np.random.random(input_shape).astype(np.float32) * 20
     layer = LinearLayer(in_channels, out_channels)
@@ -52,11 +54,3 @@ def _test_linear_backward(input_shape, out_channels):
 
     utils.assert_close(out_grad, torch_input.grad, atol=TOLERANCE)
     utils.check_linear_grad_match(layer, torch_layer, tolerance=TOLERANCE)
-
-
-def test_linear_backward():
-    for batch_size in range(1, 4):
-        for input_channels in range(1, 5):
-            for output_channels in range(1, 5):
-                input_shape = (batch_size, input_channels)
-                _test_linear_backward(input_shape, output_channels)

--- a/tests/hw1_tests/test_softmax_cross_entropy_loss_layer.py
+++ b/tests/hw1_tests/test_softmax_cross_entropy_loss_layer.py
@@ -1,11 +1,15 @@
+import pytest
+
 import numpy as np
 import torch.nn.functional as F
 
 from nn.layers.losses import SoftmaxCrossEntropyLossLayer
 from tests import utils
 
-
-def _test_forward(input_shape, reduction, axis):
+@pytest.mark.parametrize("input_shape", [(20, 10)])
+@pytest.mark.parametrize("reduction", ['mean', 'sum'])
+@pytest.mark.parametrize("axis", [1])
+def test_forward(input_shape, reduction, axis):
     layer = SoftmaxCrossEntropyLossLayer(reduction=reduction)
     data = np.random.random(input_shape) * 2 - 1
     labels_shape = list(data.shape)
@@ -22,14 +26,10 @@ def _test_forward(input_shape, reduction, axis):
 
     utils.assert_close(loss, pytorch_loss, atol=0.001)
 
-
-def test_forward_easy():
-    input_shape = (20, 10)
-    _test_forward(input_shape, "mean", 1)
-    _test_forward(input_shape, "sum", 1)
-
-
-def _test_forward_overflow(input_shape, reduction, axis):
+@pytest.mark.parametrize("input_shape", [(20, 10)])
+@pytest.mark.parametrize("reduction", ['mean', 'sum'])
+@pytest.mark.parametrize("axis", [1])
+def test_forward_overflow(input_shape, reduction, axis):
     layer = SoftmaxCrossEntropyLossLayer(reduction=reduction)
     data = np.random.random(input_shape) * 10000 - 1
     labels_shape = list(data.shape)
@@ -47,21 +47,16 @@ def _test_forward_overflow(input_shape, reduction, axis):
     utils.assert_close(loss, pytorch_loss, atol=0.001)
 
 
-def test_forward_overflow():
-    input_shape = (20, 10)
-    _test_forward_overflow(input_shape, "mean", 1)
-    _test_forward_overflow(input_shape, "sum", 1)
+@pytest.mark.parametrize("input_shape", [(20, 10, 5)])
+@pytest.mark.parametrize("reduction", ['mean', 'sum'])
+@pytest.mark.parametrize("axis", [1, 2])
+def test_forward_hard(input_shape, reduction, axis):
+    test_forward(input_shape, reduction, axis)
 
-
-def test_forward_hard():
-    input_shape = (20, 10, 5)
-    _test_forward(input_shape, "mean", 1)
-    _test_forward(input_shape, "sum", 1)
-    _test_forward(input_shape, "mean", 2)
-    _test_forward(input_shape, "sum", 2)
-
-
-def _test_backward(input_shape, reduction, axis):
+@pytest.mark.parametrize("input_shape", [(20, 10)])
+@pytest.mark.parametrize("reduction", ['mean', 'sum'])
+@pytest.mark.parametrize("axis", [1])
+def test_backward(input_shape, reduction, axis):
     layer = SoftmaxCrossEntropyLossLayer(reduction=reduction)
     data = np.random.random(input_shape) * 2 - 1
     labels_shape = list(data.shape)
@@ -87,28 +82,14 @@ def _test_backward(input_shape, reduction, axis):
 
     utils.assert_close(grad, torch_grad, atol=0.001)
 
+@pytest.mark.parametrize("input_shape", [(20, 10, 5)])
+@pytest.mark.parametrize("reduction", ['mean', 'sum'])
+@pytest.mark.parametrize("axis", [1, 2])
+def test_backward_hard(input_shape, reduction, axis):
+    test_backward(input_shape, reduction, axis)
 
-def test_backward_easy():
-    input_shape = (20, 10)
-    _test_backward(input_shape, "mean", 1)
-    _test_backward(input_shape, "sum", 1)
-
-
-def test_backward_hard():
-    input_shape = (20, 10, 5)
-    _test_backward(input_shape, "mean", 1)
-    _test_backward(input_shape, "sum", 1)
-    _test_backward(input_shape, "mean", 2)
-    _test_backward(input_shape, "sum", 2)
-
-
-def test_backward_harder():
-    input_shape = (20, 10, 5, 23)
-    _test_backward(input_shape, "mean", 0)
-    _test_backward(input_shape, "sum", 0)
-    _test_backward(input_shape, "mean", 1)
-    _test_backward(input_shape, "sum", 1)
-    _test_backward(input_shape, "mean", 2)
-    _test_backward(input_shape, "sum", 2)
-    _test_backward(input_shape, "mean", 3)
-    _test_backward(input_shape, "sum", 3)
+@pytest.mark.parametrize("input_shape", [(20, 10, 5, 23)])
+@pytest.mark.parametrize("reduction", ['mean', 'sum'])
+@pytest.mark.parametrize("axis", [0, 1, 2, 3])
+def test_backward_harder(input_shape, reduction, axis):
+    test_backward(input_shape, reduction, axis)


### PR DESCRIPTION
Hi, 

refactoring unit tests to use `@pytest.mark.parametrize(`. This way it is much easier to know exactly which set of parameters are failing and also allows to run tests with specific parameter independently. VS code also sees each parameter set separately and you could debug separately.

Here is a screen shot of VS codes tests window.

![image](https://user-images.githubusercontent.com/7648675/115156866-440ab880-a03b-11eb-930f-01da8035893c.png)
